### PR TITLE
 fix thread-clean order and provide tang response as a json in +threa…

### DIFF
--- a/pkg/arvo/app/spider.hoon
+++ b/pkg/arvo/app/spider.hoon
@@ -554,9 +554,12 @@
     ~
   %+  give-simple-payload:app:server  u.eyre-id
   ^-  simple-payload:http
-  :_  ~  :_  ~
   ?.  ?=(http-error:spider term)
-    ((slog tang) 500)
+    %-  (slog tang)
+    =/  tube  (convert-tube %tang %json desk bowl)
+    %-  json-response:gen:server
+    o/(malt `(list [key=@t json])`[term+s/term tang+!<(json (tube !>(tang))) ~])
+  :_  ~  :_  ~
   ?-  term
     %bad-request  400
     %forbidden    403
@@ -570,9 +573,9 @@
   ::%-  (slog leaf+"strand {<yarn>} failed" leaf+<term> tang)
   =/  =tid  (yarn-to-tid yarn)
   =/  fail-cards  (thread-say-fail tid term tang)
-  =^  cards       state  (thread-clean yarn)
   =^  http-cards  state  (thread-http-fail tid term tang)
   =^  scry-card   state  (cancel-scry tid silent=%.n)
+  =^  cards       state  (thread-clean yarn)
   :_  state
   :(weld fail-cards cards http-cards scry-card)
 ::


### PR DESCRIPTION
(1) In `+thread-fail`, `+thread-clean` is called before `+thread-http-fail` and `+cancel-scry` meaning neither of the latter two actually run in any meaningful way. `serving` has been replaced with `(~(del by serving.state) tid)` in the state and therefore we cannot `(~(get by serving.state) tid)` in `+thread-http-fail` or `+cancel-scry`.

(2) In `+thread-http-fail` return an informative tang as json instead of an empty 500 http response when the failure results from an internal crash.